### PR TITLE
Add gpg command-line tool (a.k.a. GnuPG, PGP)

### DIFF
--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -4,7 +4,7 @@ WORKDIR /root
 
 ARG VERSION=8.0.33
 
-RUN yum -y update && yum install -y cmake3 make gcc-c++ ncurses-devel openssl11 openssl11-devel python-devel wget tar gzip which zip unzip
+RUN yum -y update && yum install -y cmake3 make gcc-c++ ncurses-devel openssl11 openssl11-devel python-devel wget tar gzip which gnupg2 zip unzip
 
 RUN wget -q https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-${VERSION}.tar.gz
 
@@ -16,6 +16,6 @@ RUN cd /opt; strip bin/* lib/*; rm lib/*.a;
 
 # Remove binaries that are too large that we don't need
 RUN cd /opt/bin; mv mysql mysqldump ..; rm *; cd ..; mv mysql mysqldump ./bin
-RUN cd /usr/bin; cp zip unzip /opt/bin
+RUN cd /usr/bin; cp gpg zip unzip /opt/bin
 
 RUN cd /opt; zip -9ry /root/mysql-${VERSION}-layer.zip bin lib


### PR DESCRIPTION
Add the gpg command-line tool, so we can decrypt files.

# To test

1. Check out a working copy
2. If you already have a `mysql-8.0.33-layer.zip` file, delete it
3. Start Docker desktop
4. Run `make mysql`
5. Wait

At the end, you should have a new zip file, `mysql-8.0.33-layer.zip`.

It should have contents like this:

```
david@Davids-MacBook-Pro-2 tmp9 % ll -R
total 17112
drwxr-xr-x   7 david  staff      224 21 Oct 14:33 bin
drwxr-xr-x  10 david  staff      320 21 Oct 14:33 lib

./bin:
total 32040
-rwxr-xr-x  1 david  staff   729536 21 Oct 14:33 gpg
-rwxr-xr-x  1 david  staff  7734024 21 Oct 14:33 mysql
-rwxr-xr-x  1 david  staff  7520520 21 Oct 14:33 mysqldump
-rwxr-xr-x  1 david  staff   189472 21 Oct 14:33 unzip
-rwxr-xr-x  1 david  staff   215688 21 Oct 14:33 zip

./lib:
total 22480
-rwxr-xr-x  1 david  staff  3010624 21 Oct 14:33 libcrypto.so.1.1
lrwxrwxrwx  1 david  staff       20 21 Oct 14:36 libmysqlclient.so -> libmysqlclient.so.21
lrwxrwxrwx  1 david  staff       25 21 Oct 14:36 libmysqlclient.so.21 -> libmysqlclient.so.21.2.33
-rwxr-xr-x  1 david  staff  7556960 21 Oct 14:33 libmysqlclient.so.21.2.33
-rwxr-xr-x  1 david  staff   164600 21 Oct 14:33 libncurses.so.6
-rwxr-xr-x  1 david  staff   589320 21 Oct 14:33 libssl.so.1.1
-rwxr-xr-x  1 david  staff   179328 21 Oct 14:33 libtinfo.so.6
drwxr-xr-x  3 david  staff       96 21 Oct 14:33 pkgconfig

./lib/pkgconfig:
total 8
-rw-r--r--  1 david  staff  1394 21 Oct 14:21 mysqlclient.pc
david@Davids-MacBook-Pro-2 tmp9 %
```

As for whether the contents actually work, you can wait to test in the PR that adds the output file to asknicelydo.